### PR TITLE
CDCD merge with rest of diffusion classes

### DIFF
--- a/src/refactor/models/diffusion/ddpm.py
+++ b/src/refactor/models/diffusion/ddpm.py
@@ -3,11 +3,7 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 import tqdm
-<<<<<<< HEAD
 from refactor.models.diffusion.diffusion import DiffusionModel
-=======
-from models.diffusion.diffusion import DDPM
->>>>>>> integrate score interpolation code with DDPM
 from torch import nn
 from utils.misc import extract, extract_data_from_batch, mean_flat
 from utils.schedules import (
@@ -17,7 +13,7 @@ from utils.schedules import (
 )
 
 
-class DDPM(DDPM):
+class DDPM(DiffusionModel):
     def __init__(
         self,
         *,

--- a/src/refactor/models/diffusion/ddpm.py
+++ b/src/refactor/models/diffusion/ddpm.py
@@ -3,7 +3,11 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 import tqdm
+<<<<<<< HEAD
 from refactor.models.diffusion.diffusion import DiffusionModel
+=======
+from models.diffusion.diffusion import DDPM
+>>>>>>> integrate score interpolation code with DDPM
 from torch import nn
 from utils.misc import extract, extract_data_from_batch, mean_flat
 from utils.schedules import (
@@ -13,7 +17,7 @@ from utils.schedules import (
 )
 
 
-class DDPM(DiffusionModel):
+class DDPM(DDPM):
     def __init__(
         self,
         *,
@@ -70,7 +74,7 @@ class DDPM(DiffusionModel):
 
         # Equation 11 in the paper
         # Use our model (noise predictor) to predict the mean
-        model_mean = sqrt_recip_alphas_t * (x - betas_t * self.model(x, time=t) / sqrt_one_minus_alphas_cumprod_t)
+        model_mean = sqrt_recip_alphas_t * (x - betas_t * self.score_f(x, time=t) / sqrt_one_minus_alphas_cumprod_t)
 
         if t_index == 0:
             return model_mean
@@ -79,6 +83,9 @@ class DDPM(DiffusionModel):
             noise = torch.randn_like(x)
             # Algorithm 2 line 4:
             return model_mean + torch.sqrt(posterior_variance_t) * noise
+        
+    def score_f(self, *args, **kwargs): 
+        return self.model(*args, **kwargs)
 
     @torch.no_grad()
     def p_sample_guided(self, x, classes, t, t_index, context_mask, cond_weight=0.0):
@@ -96,7 +103,7 @@ class DDPM(DiffusionModel):
         classes_masked = classes * context_mask
         classes_masked = classes_masked.type(torch.long)
         # print ('class masked', classes_masked)
-        preds = self.model(x_double, time=t_double, classes=classes_masked)
+        preds = self.score_f(x_double, time=t_double, classes=classes_masked)
         eps1 = (1 + cond_weight) * preds[:batch_size]
         eps2 = cond_weight * preds[batch_size:]
         x_t = eps1 - eps2
@@ -148,7 +155,6 @@ class DDPM(DiffusionModel):
             total=self.timesteps,
         ):
             image = sampling_fn(
-                self.model,
                 x=image,
                 t=torch.full((b,), i, device=device, dtype=torch.long),
                 t_index=i,

--- a/src/refactor/models/diffusion/diffusion.py
+++ b/src/refactor/models/diffusion/diffusion.py
@@ -9,12 +9,8 @@ from refactor.utils.schedules import cosine_beta_schedule, linear_beta_schedule,
 from utils.ema import EMA
 
 
-<<<<<<< HEAD
 
 class DiffusionModel(pl.LightningModule):
-=======
-class DDPM(pl.LightningModule):
->>>>>>> integrate score interpolation code with DDPM
     def __init__(
         self,
         unet: nn.Module,

--- a/src/refactor/models/diffusion/diffusion.py
+++ b/src/refactor/models/diffusion/diffusion.py
@@ -9,8 +9,12 @@ from refactor.utils.schedules import cosine_beta_schedule, linear_beta_schedule,
 from utils.ema import EMA
 
 
+<<<<<<< HEAD
 
 class DiffusionModel(pl.LightningModule):
+=======
+class DDPM(pl.LightningModule):
+>>>>>>> integrate score interpolation code with DDPM
     def __init__(
         self,
         unet: nn.Module,

--- a/src/refactor/models/diffusion/score_interpolation.py
+++ b/src/refactor/models/diffusion/score_interpolation.py
@@ -1,0 +1,275 @@
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+import tqdm
+from models.diffusion.diffusion import DiffusionModel
+from torch import nn
+from utils.misc import extract, extract_data_from_batch, mean_flat
+from utils.schedules import (
+    alpha_cosine_log_snr,
+    beta_linear_log_snr,
+    linear_beta_schedule,
+)
+
+
+class ScoreInterpolationModel(DiffusionModel):
+    def __init__(
+        self,
+        *,
+        image_size,
+        timesteps=50,
+        noise_schedule="cosine",
+        time_difference=0.0,
+        network: nn.Module,
+        is_conditional: bool,
+        p_uncond: float = 0.1,
+        use_fp16: bool,
+        logdir: str,
+        optimizer: torch.optim.Optimizer,
+        lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
+        criterion: nn.Module,
+        use_ema: bool = True,
+        ema_decay: float = 0.9999,
+        lr_warmup=0,
+        use_p2_weigthing: bool = False,
+        p2_gamma: float = 0.5,
+        p2_k: float = 1,
+    ):
+        super().__init__(
+            network,
+            is_conditional,
+            use_fp16,
+            logdir,
+            optimizer,
+            lr_scheduler,
+            criterion,
+            use_ema,
+            ema_decay,
+            lr_warmup,
+        )
+        self.image_size = image_size
+
+        if noise_schedule == "linear":
+            self.log_snr = beta_linear_log_snr
+        elif noise_schedule == "cosine":
+            self.log_snr = alpha_cosine_log_snr
+        else:
+            raise ValueError(f"invalid noise schedule {noise_schedule}")
+
+        self.timesteps = timesteps
+        self.p_uncond = p_uncond
+
+        # self.betas = cosine_beta_schedule(timesteps=timesteps,  s=0.0001)
+        self.set_noise_schedule(self.betas, self.timesteps)
+
+        # proposed in the paper, summed to time_next
+        # as a way to fix a deficiency in self-conditioning and lower FID when the number of sampling timesteps is < 400
+
+        self.time_difference = time_difference
+
+    def set_noise_schedule(self, betas, timesteps):
+        # define beta schedule
+        self.betas = linear_beta_schedule(timesteps=timesteps, beta_end=0.05)
+
+        # define alphas
+        alphas = 1.0 - self.betas
+        alphas_cumprod = torch.cumprod(alphas, axis=0)
+        alphas_cumprod_prev = F.pad(alphas_cumprod[:-1], (1, 0), value=1.0)
+
+        self.sqrt_recip_alphas = torch.sqrt(1.0 / alphas)
+
+        # calculations for diffusion q(x_t | x_{t-1}) and others
+        self.sqrt_alphas_cumprod = torch.sqrt(alphas_cumprod)
+
+        # sqrt_one_minus_alphas_cumprod = torch.sqrt(1. - alphas_cumprod)
+        self.sqrt_one_minus_alphas_cumprod = torch.sqrt(1.0 - alphas_cumprod)
+
+        # calculations for posterior q(x_{t-1} | x_t, x_0)
+        self.posterior_variance = betas * (1.0 - alphas_cumprod_prev) / (1.0 - alphas_cumprod)
+
+    def q_sample(self, x_start, t, noise=None):
+        """
+        Forward pass with noise.
+        """
+        if noise is None:
+            noise = torch.randn_like(x_start)
+
+        sqrt_alphas_cumprod_t = extract(self.sqrt_alphas_cumprod, t, x_start.shape)
+        sqrt_one_minus_alphas_cumprod_t = extract(self.sqrt_one_minus_alphas_cumprod, t, x_start.shape)
+
+        return sqrt_alphas_cumprod_t * x_start + sqrt_one_minus_alphas_cumprod_t * noise
+
+    @torch.no_grad()
+    def p_sample(self, x, t, t_index):
+        betas_t = extract(self.betas, t, x.shape)
+        sqrt_one_minus_alphas_cumprod_t = extract(self.sqrt_one_minus_alphas_cumprod, t, x.shape)
+        # print (x.shape, 'x_shape')
+        sqrt_recip_alphas_t = extract(self.sqrt_recip_alphas, t, x.shape)
+
+        # Equation 11 in the paper
+        # Use our model (noise predictor) to predict the mean
+        model_mean = sqrt_recip_alphas_t * (x - betas_t * self.model(x, time=t) / sqrt_one_minus_alphas_cumprod_t)
+
+        if t_index == 0:
+            return model_mean
+        else:
+            posterior_variance_t = extract(self.posterior_variance, t, x.shape)
+            noise = torch.randn_like(x)
+            # Algorithm 2 line 4:
+            return model_mean + torch.sqrt(posterior_variance_t) * noise
+
+    @torch.no_grad()
+    def p_sample_guided(self, x, classes, t, t_index, context_mask, cond_weight=0.0):
+        # adapted from: https://openreview.net/pdf?id=qw8AKxfYbI
+        # print (classes[0])
+        batch_size = x.shape[0]
+        # double to do guidance with
+        t_double = t.repeat(2)
+        x_double = x.repeat(2, 1, 1, 1)
+        betas_t = extract(self.betas, t_double, x_double.shape)
+        sqrt_one_minus_alphas_cumprod_t = extract(self.sqrt_one_minus_alphas_cumprod, t_double, x_double.shape)
+        sqrt_recip_alphas_t = extract(self.sqrt_recip_alphas, t_double, x_double.shape)
+
+        # classifier free sampling interpolates between guided and non guided using `cond_weight`
+        classes_masked = classes * context_mask
+        classes_masked = classes_masked.type(torch.long)
+        # print ('class masked', classes_masked)
+        preds = self.model(x_double, time=t_double, classes=classes_masked)
+        eps1 = (1 + cond_weight) * preds[:batch_size]
+        eps2 = cond_weight * preds[batch_size:]
+        x_t = eps1 - eps2
+
+        # Equation 11 in the paper
+        # Use our model (noise predictor) to predict the mean
+        model_mean = sqrt_recip_alphas_t[:batch_size] * (
+            x - betas_t[:batch_size] * x_t / sqrt_one_minus_alphas_cumprod_t[:batch_size]
+        )
+
+        if t_index == 0:
+            return model_mean
+        else:
+            posterior_variance_t = extract(self.posterior_variance, t, x.shape)
+            noise = torch.randn_like(x)
+            # Algorithm 2 line 4:
+            return model_mean + torch.sqrt(posterior_variance_t) * noise
+
+    # Algorithm 2 but save all images:
+    @torch.no_grad()
+    def p_sample_loop(self, classes, shape, cond_weight):
+        device = next(self.model.parameters()).device
+
+        b = shape[0]
+        # start from pure noise (for each example in the batch)
+        image = torch.randn(shape, device=device)
+        images = []
+
+        if classes is not None:
+            n_sample = classes.shape[0]
+            context_mask = torch.ones_like(classes).to(device)
+            # make 0 index unconditional
+            # double the batch
+            classes = classes.repeat(2)
+            context_mask = context_mask.repeat(2)
+            context_mask[n_sample:] = 0.0  # makes second half of batch context free
+            sampling_fn = partial(
+                self.p_sample_guided,
+                classes=classes,
+                cond_weight=cond_weight,
+                context_mask=context_mask,
+            )
+        else:
+            sampling_fn = partial(self.p_sample)
+
+        for i in tqdm(
+            reversed(range(0, self.timesteps)),
+            desc="sampling loop time step",
+            total=self.timesteps,
+        ):
+            image = sampling_fn(
+                self.model,
+                x=image,
+                t=torch.full((b,), i, device=device, dtype=torch.long),
+                t_index=i,
+            )
+            images.append(image.cpu().numpy())
+        return images
+
+    @torch.no_grad()
+    def sample(self, image_size, classes=None, batch_size=16, channels=3, cond_weight=0):
+        return self.p_sample_loop(
+            self.model,
+            classes=classes,
+            shape=(batch_size, channels, 4, image_size),
+            cond_weight=cond_weight,
+        )
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int):
+        x_start, condition = extract_data_from_batch(batch)
+
+        if noise is None:
+            noise = torch.randn_like(x_start)
+        x_noisy = self.q_sample(x_start=x_start, t=self.timesteps, noise=noise)
+
+        # calculating generic loss function, we'll add it to the class constructor once we have the code
+        # we should log more metrics at train and validation e.g. l1, l2 and other suggestions
+        if self.use_fp16:
+            with torch.cuda.amp.autocast():
+                if self.is_conditional:
+                    predicted_noise = self.model(x_noisy, self.timesteps, condition)
+                else:
+                    predicted_noise = self.model(x_noisy, self.timesteps)
+        else:
+            if self.is_conditional:
+                predicted_noise = self.model(x_noisy, self.timesteps, condition)
+            else:
+                predicted_noise = self.model(x_noisy, self.timesteps)
+
+        loss = self.criterion(predicted_noise, noise)
+        self.log("train", loss, batch_size=batch.shape[0])
+
+        return loss
+
+    def validation_step(self, batch: torch.Tensor, batch_idx: int):
+        return self.inference_step(batch, batch_idx, "validation")
+
+    def test_step(self, batch: torch.Tensor, batch_idx: int):
+        return self.inference_step(batch, batch_idx, "test")
+
+    def inference_step(self, batch: torch.Tensor, batch_idx: int, phase="validation", noise=None):
+        x_start, condition = extract_data_from_batch(batch)
+        device = x_start.device
+        batch_size = batch.shape[0]
+
+        t = torch.randint(0, self.timesteps, (batch_size,), device=device).long()  # sampling a t to generate t and t+1
+
+        if noise is None:
+            noise = torch.randn_like(x_start)  #  gauss noise
+        x_noisy = self.q_sample(x_start=x_start, t=t, noise=noise)  # this is the auto generated noise given t and Noise
+
+        context_mask = torch.bernoulli(torch.zeros(classes.shape[0]) + (1 - self.p_uncond)).to(device)
+
+        # mask for unconditinal guidance
+        classes = classes * context_mask
+        classes = classes.type(torch.long)
+
+        predictions = self.model(x_noisy, t, condition)
+
+        loss = self.criterion(predictions, batch)
+
+        self.log("validation_loss", loss) if phase == "validation" else self.log("test_loss", loss)
+
+        """
+            Log multiple losses at validation/test time according to internal discussions.
+        """
+
+        return predictions
+
+    def p2_weighting(self, x_t, ts, target, prediction):
+        """
+        From Perception Prioritized Training of Diffusion Models: https://arxiv.org/abs/2204.00227.
+        """
+        weight = (1 / (self.p2_k + self.snr) ** self.p2_gamma, ts, x_t.shape)
+        loss_batch = mean_flat(weight * (target - prediction) ** 2)
+        loss = torch.mean(loss_batch)
+        return loss

--- a/src/refactor/models/diffusion/score_interpolation.py
+++ b/src/refactor/models/diffusion/score_interpolation.py
@@ -212,10 +212,10 @@ class ScoreInterpolationModel(DiffusionModel):
         time_delta: float = 0.0,
         cond_weight=0
     ):        
+        model = self.model
 
         b = shape[0]
         embed_t = torch.randn(shape)
-        model = self.model
 
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
         def predict_embeddings(x_noisy, prev_embeds, t, classes):
@@ -253,7 +253,7 @@ class ScoreInterpolationModel(DiffusionModel):
             desc="sampling loop time step",
             total=timesteps,
         ):
-
+            
             def compute_score_interpolation(embed_t, time, classes):
                 nonlocal prev_embeds
                 prev_embeds = predict_embeddings(embed_t, prev_embeds, time, classes)
@@ -265,6 +265,7 @@ class ScoreInterpolationModel(DiffusionModel):
 
             # project to output space
             out = model.linear_out(embed_t)
+            out = rearrange(out, "b w s nucl -> b w nucl s")
             out = torch.softmax(out, dim=-2)
             images.append(out.cpu().numpy())
         

--- a/src/refactor/models/networks/cdcd_transformer.py
+++ b/src/refactor/models/networks/cdcd_transformer.py
@@ -1,0 +1,74 @@
+from einops import rearrange
+from src.refactor.utils.misc import default
+from src.refactor.utils.network import CDCDTransformerEncoder, LearnedSinusoidalPosEmb
+import torch
+from torch import nn
+
+
+class CDCDTransformer(nn.Module):
+    """
+    Refer to the main paper for the architecture details https://arxiv.org/pdf/2208.04202.pdf
+    """
+
+    def __init__(
+            self,
+            dim,
+            init_dim=200,
+            out_dim=4,
+            channels=1,
+            learned_sinusoidal_dim=18,
+            num_classes=10, 
+            transformer_num_layers=1,
+            transformer_num_attention_heads=8, 
+            transformer_hidden_dim=128,
+            transformer_mlp_hidden_dim=512,
+            
+    ):
+        super().__init__()
+
+        self.channels = channels
+        self.nucleotide_embeddings = torch.nn.Embedding(4, embedding_dim=dim)
+
+        init_dim = default(init_dim, dim)
+        input_dim = init_dim*3
+        time_dim = dim * 4
+
+        sinu_pos_emb = LearnedSinusoidalPosEmb(learned_sinusoidal_dim)
+        fourier_dim = learned_sinusoidal_dim + 1
+
+        self.time_mlp = nn.Sequential(
+            sinu_pos_emb,
+            nn.Linear(fourier_dim, time_dim),
+            nn.GELU(),
+            nn.Linear(time_dim, time_dim),
+            nn.GELU()
+        )
+
+        if num_classes is not None:
+            self.label_emb = nn.Embedding(num_classes, time_dim)
+
+        self.transformer_encoder = CDCDTransformerEncoder(
+            init_dim=input_dim,
+            time_dim=time_dim,
+            num_layers=transformer_num_layers, 
+            num_attention_heads=transformer_num_attention_heads, 
+            hidden_dim=transformer_hidden_dim, 
+            mlp_hidden_dim=transformer_mlp_hidden_dim,
+            embed_dim=init_dim
+        )
+
+        self.linear_out = nn.Linear(init_dim, out_dim) # BS * seq_len * emb_dim -> BS * seq_len * 4
+
+
+    def forward(self, x, time, classes):
+        t_start = self.time_mlp(time)
+
+        if classes is not None:
+            t_start += self.label_emb(classes)
+
+        x = self.transformer_encoder(x, t_start)
+        logits = self.linear_out(x)
+
+        logits = rearrange(logits, "b w h v -> b w v h")
+        return logits
+    


### PR DESCRIPTION
This PR merges the implementation of CDCD/score interpolation with the rest of the classes already present in DNA diffusion. 

Still to be done: 

- [ ] Clean up training step 
- [ ] Implement inference step (little different to the standard diffusion one)
- [ ] Integrate time-warping logic

Note that as this is already implemented in the corresponding notebook, and aiming to extensively reuse existing code, these should be simple enough to implement. 